### PR TITLE
Fix ValueError in elevation_smooth_time for short recordings

### DIFF
--- a/chironpy/metrics/vert.py
+++ b/chironpy/metrics/vert.py
@@ -68,10 +68,22 @@ def elevation_smooth_time(elevations, sample_len=1, window_len=21, polyorder=2):
     # high-frequency noise).
     # TODO (aschroeder): Add a second, binomial filter?
     # TODO (aschroeder): Fix the scipy/signal/arraytools warning!
+    elev_list = list(elevations)
+    n = len(elev_list)
+    if n < polyorder + 2:
+        # Too few points to apply the filter; return data unsmoothed.
+        return elev_list
+
+    # Reduce window_len to fit the data; keep it odd and > polyorder.
+    if window_len > n:
+        window_len = n if n % 2 == 1 else n - 1
+        if window_len <= polyorder:
+            window_len = polyorder + 1 if (polyorder + 1) % 2 == 1 else polyorder + 2
+
     with warnings.catch_warnings():
         warnings.simplefilter(action="ignore", category=FutureWarning)
         warnings.simplefilter(action="ignore", category=RuntimeWarning)
-        elevs_smooth = savgol_filter(list(elevations), window_len, polyorder)
+        elevs_smooth = savgol_filter(elev_list, window_len, polyorder)
 
     return elevs_smooth
 

--- a/tests/metrics/test_vert.py
+++ b/tests/metrics/test_vert.py
@@ -98,3 +98,29 @@ class TestGradeSmoothTime:
         elevations = np.full(N, 100.0)
         result = grade_smooth_time(DISTANCES, elevations)
         assert np.allclose(result, 0.0, atol=1e-6)
+
+
+class TestShortRecordings:
+    """Regression tests for recordings shorter than the SG filter window."""
+
+    def test_elevation_smooth_time_short_data_no_error(self):
+        # 2-second recording: fewer points than default window_len=21
+        elevations = [100.0, 101.0]
+        result = elevation_smooth_time(elevations)
+        assert len(result) == 2
+
+    def test_elevation_smooth_time_single_point(self):
+        result = elevation_smooth_time([100.0])
+        assert len(result) == 1
+
+    def test_grade_smooth_time_short_data_no_error(self):
+        distances = [0.0, 5.0]
+        elevations = [100.0, 101.0]
+        result = grade_smooth_time(distances, elevations)
+        assert len(result) == 2
+
+    def test_elevation_smooth_time_window_boundary(self):
+        # Exactly window_len - 1 points (20 points, default window=21)
+        elevations = np.full(20, 100.0)
+        result = elevation_smooth_time(elevations)
+        assert len(result) == 20


### PR DESCRIPTION
## Summary

- Fixes `ValueError` raised by `savgol_filter` when a recording has fewer data points than the filter's `window_len` (default 21)
- Recordings too short to support any valid SG window (`n < polyorder + 2`) are returned unsmoothed
- Recordings shorter than the default window but long enough for a minimal filter use a reduced odd `window_len`

## Test plan

- [ ] `TestShortRecordings::test_elevation_smooth_time_short_data_no_error` — 2-point recording no longer raises
- [ ] `TestShortRecordings::test_elevation_smooth_time_single_point` — single-point recording works
- [ ] `TestShortRecordings::test_grade_smooth_time_short_data_no_error` — end-to-end 2-point grade calculation works
- [ ] `TestShortRecordings::test_elevation_smooth_time_window_boundary` — 20-point recording (one below default window) works
- [ ] Existing `TestElevationSmoothTime` and `TestGradeSmoothTime` tests still pass

Closes #11

https://claude.ai/code/session_01KCry3qwcebuPqnKEzWbTsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCry3qwcebuPqnKEzWbTsK)_