### PR TITLE
Fix distance not accumulating across merged workouts

### DIFF
--- a/chironpy/models/workout.py
+++ b/chironpy/models/workout.py
@@ -458,19 +458,30 @@ class WorkoutData(pd.DataFrame):
 
         # Offset distance so it accumulates continuously across workouts.
         # Each workout's distance resets to 0 (or its own baseline); add the
-        # running total from all previous workouts so the merged series is
-        # monotonically increasing.
+        # running cumulative total at the start of the current workout so the
+        # merged series is monotonically non-decreasing.  For overlapping
+        # workouts the offset is looked up at the exact start timestamp of the
+        # current workout (not the end of the previous one), which avoids an
+        # artificial jump at the overlap boundary.
         if len(frames) > 1:
-            running_offset = 0.0
-            for i, frame in enumerate(frames):
-                if "distance" not in frame.columns:
+            running_dist = (
+                frames[0]["distance"].dropna()
+                if "distance" in frames[0].columns
+                else pd.Series(dtype=float)
+            )
+            for i in range(1, len(frames)):
+                if "distance" not in frames[i].columns:
                     continue
-                if i > 0 and running_offset != 0.0:
-                    frames[i] = frame.copy()
-                    frames[i]["distance"] = frame["distance"] + running_offset
-                last_dist = frames[i]["distance"].dropna()
-                if not last_dist.empty:
-                    running_offset = float(last_dist.iloc[-1])
+                start_ts = frames[i].index[0]
+                prior = running_dist.loc[:start_ts].dropna()
+                offset = float(prior.iloc[-1]) if not prior.empty else 0.0
+                if offset != 0.0:
+                    frames[i] = frames[i].copy()
+                    frames[i]["distance"] = frames[i]["distance"] + offset
+                # Merge this frame's (offset) distance into the running series;
+                # later-starting workout wins at overlapping timestamps.
+                updated = pd.concat([running_dist, frames[i]["distance"].dropna()])
+                running_dist = updated[~updated.index.duplicated(keep="last")].sort_index()
 
         if drop_gaps:
             # Shift each workout to start 1 second after the previous one ends

--- a/chironpy/models/workout.py
+++ b/chironpy/models/workout.py
@@ -456,6 +456,22 @@ class WorkoutData(pd.DataFrame):
         # Sort ascending by each workout's first timestamp
         frames.sort(key=lambda df: df.index[0])
 
+        # Offset distance so it accumulates continuously across workouts.
+        # Each workout's distance resets to 0 (or its own baseline); add the
+        # running total from all previous workouts so the merged series is
+        # monotonically increasing.
+        if len(frames) > 1:
+            running_offset = 0.0
+            for i, frame in enumerate(frames):
+                if "distance" not in frame.columns:
+                    continue
+                if i > 0 and running_offset != 0.0:
+                    frames[i] = frame.copy()
+                    frames[i]["distance"] = frame["distance"] + running_offset
+                last_dist = frames[i]["distance"].dropna()
+                if not last_dist.empty:
+                    running_offset = float(last_dist.iloc[-1])
+
         if drop_gaps:
             # Shift each workout to start 1 second after the previous one ends
             # so resampling produces a contiguous time range with no gap rows.

--- a/chironpy/models/workout.py
+++ b/chironpy/models/workout.py
@@ -481,7 +481,9 @@ class WorkoutData(pd.DataFrame):
                 # Merge this frame's (offset) distance into the running series;
                 # later-starting workout wins at overlapping timestamps.
                 updated = pd.concat([running_dist, frames[i]["distance"].dropna()])
-                running_dist = updated[~updated.index.duplicated(keep="last")].sort_index()
+                running_dist = updated[
+                    ~updated.index.duplicated(keep="last")
+                ].sort_index()
 
         if drop_gaps:
             # Shift each workout to start 1 second after the previous one ends

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,12 @@ Types of changes:
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-05-26
+
+### Fixed
+
+- Fixed `WorkoutData.merge_many()` not accumulating distance across workouts. Each source workout stores distance starting from 0; the merged series now correctly offsets each subsequent workout's distance by the cumulative total of all preceding workouts, producing a monotonically non-decreasing distance column suitable for use as a chart x-axis.
+
 ## [0.30.0] - 2026-05-04
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chironpy"
-version = "0.30.0"
+version = "0.30.1"
 description = "Workout analysis"
 license = { text = "MIT" }
 authors = [{ name = "Clive Gross", email = "clive@chironapp.com" }]

--- a/tests/test_merge_workouts.py
+++ b/tests/test_merge_workouts.py
@@ -187,7 +187,9 @@ def test_distance_continuous_at_overlap_boundary(workout_a, workout_b):
     merged = WorkoutData.merge_many([workout_a, workout_b_overlapping])
 
     assert overlap_start in merged.index, "Expected merged to contain overlap_start"
-    assert overlap_start in workout_a.index, "Expected workout_a to contain overlap_start"
+    assert overlap_start in workout_a.index, (
+        "Expected workout_a to contain overlap_start"
+    )
 
     dist_at_overlap_in_a = workout_a.loc[overlap_start, "distance"]
     dist_at_overlap_in_merged = merged.loc[overlap_start, "distance"]

--- a/tests/test_merge_workouts.py
+++ b/tests/test_merge_workouts.py
@@ -172,3 +172,27 @@ def test_overlapping_later_workout_values_take_precedence(workout_a, workout_b):
     assert merged.loc[sample_ts, "speed"] == pytest.approx(
         workout_b_overlapping.loc[sample_ts, "speed"]
     )
+
+
+def test_distance_continuous_at_overlap_boundary(workout_a, workout_b):
+    """Distance must not jump at the boundary where a later workout overlaps an earlier one.
+
+    When workout_b is shifted to start inside workout_a's time range, the
+    merged distance at overlap_start should equal workout_a's distance at
+    that same timestamp — not workout_a's final distance (which would be
+    an over-shoot causing an artificial jump).
+    """
+    overlap_start = workout_a.index[-1] - pd.Timedelta(minutes=5)
+    workout_b_overlapping = workout_b.set_start_time(overlap_start)
+    merged = WorkoutData.merge_many([workout_a, workout_b_overlapping])
+
+    assert overlap_start in merged.index, "Expected merged to contain overlap_start"
+    assert overlap_start in workout_a.index, "Expected workout_a to contain overlap_start"
+
+    dist_at_overlap_in_a = workout_a.loc[overlap_start, "distance"]
+    dist_at_overlap_in_merged = merged.loc[overlap_start, "distance"]
+
+    assert dist_at_overlap_in_merged == pytest.approx(dist_at_overlap_in_a, rel=1e-3), (
+        "distance in merged workout jumped at the overlap boundary — "
+        "expected it to equal workout_a's distance at that timestamp"
+    )

--- a/tests/test_merge_workouts.py
+++ b/tests/test_merge_workouts.py
@@ -69,6 +69,29 @@ def test_distance_forward_filled_during_gap(merged, workout_a, workout_b):
     )
 
 
+def test_distance_accumulates_across_workouts(merged, workout_a, workout_b, workout_c):
+    """Distance must be monotonically non-decreasing across all three workouts.
+
+    Each source workout starts its distance from 0; after merging the values
+    must be offset so that workout B continues from where A ended and workout C
+    continues from where B ended — not resetting to 0 at each boundary.
+    """
+    dist = merged["distance"].dropna()
+    assert not dist.empty, "Merged workout has no distance data"
+    assert (dist.diff().dropna() >= 0).all(), (
+        "distance decreased somewhere in the merged workout — "
+        "distances from subsequent workouts were not offset correctly"
+    )
+    # The merged max distance must exceed workout_a's alone, confirming B and C
+    # were offset rather than overwriting.
+    end_a = workout_a["distance"].dropna().iloc[-1]
+    end_b = workout_b["distance"].dropna().iloc[-1]
+    assert dist.max() > end_a + end_b, (
+        "merged max distance should exceed workout_a + workout_b alone; "
+        "workout_c distance was not accumulated"
+    )
+
+
 def test_speed_and_heartrate_nan_during_gap(merged, workout_a, workout_b):
     """Performance channels (speed, heartrate) must be NaN in gap rows."""
     gap_rows = merged.loc[


### PR DESCRIPTION
## Summary

- `merge_many` was concatenating each workout's distance column as-is, so distance reset to 0 at each workout boundary instead of continuing from the previous workout's final value
- Fixed by offsetting each subsequent workout's distance by the cumulative total of all preceding workouts before `pd.concat`
- Added `test_distance_accumulates_across_workouts` which asserts the merged distance is monotonically non-decreasing and that all three workouts' distances are properly accumulated

## Root cause

Each source workout (FIT/Strava/etc.) stores distance starting from 0. `merge_many` sorted and concatenated frames without adjusting the distance values, so a chart with distance on the x-axis would show the values dropping back to 0 at every workout boundary.

## Test plan

- [ ] Run `pytest tests/test_merge_workouts.py` — new test `test_distance_accumulates_across_workouts` should pass
- [ ] Manually verify a 3-workout merge plotted with distance on x-axis shows a continuously increasing curve

https://claude.ai/code/session_017B4tdGrVJwKKN224uy5s5z

---
_Generated by [Claude Code](https://claude.ai/code/session_017B4tdGrVJwKKN224uy5s5z)_